### PR TITLE
Bug fix in Python 2.6.1

### DIFF
--- a/tiddlylisp.py
+++ b/tiddlylisp.py
@@ -196,7 +196,7 @@ def repl(prompt='tiddlylisp> '):
             if val is not None: print to_string(val)
         except KeyboardInterrupt:
             print "\nExiting tiddlylisp\n"
-            exit()
+            sys.exit()
         except:
             handle_error()
 


### PR DESCRIPTION
I was working through the excellent lisp article here: http://www.michaelnielsen.org/ddi/lisp-as-the-maxwells-equations-of-software/

when I notice that that ^C wasn't doing the right thing:

$ python tiddlylisp.py
tiddlylisp> ^C
Exiting tiddlylisp

Traceback (most recent call last):
  File "tiddlylisp.py", line 218, in <module>
    repl()
  File "tiddlylisp.py", line 199, in repl
    exit()
NameError: global name 'exit' is not defined

Apparently 'exit()' isn't built in python 2.6 and is rather a part of the sys namespace (which you had conveniently already imported).  This seems to fix the problem.

Peace
~Sam Auciello
http://samauciello.com
